### PR TITLE
Azure Start Airflow On VM using KeyVault Secrets

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+{$DOMAIN_NAME} {
+    reverse_proxy airflow-apiserver:8080
+}

--- a/config/webserver_config.py
+++ b/config/webserver_config.py
@@ -31,7 +31,6 @@ OAUTH_PROVIDERS = [
             "request_token_url": None,
             "client_id": os.environ.get('AAD_CLIENT_ID'),
             "client_secret": os.environ.get('AAD_CLIENT_SECRET'),
-            "redirect_uri": os.environ.get('AZURE_REDIRECT_URI', "http://localhost:8080/oauth-authorized/azure")
         },
     },
 ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,14 +53,17 @@ x-airflow-common:
   build: .
   environment:
     &airflow-common-env
+    AIRFLOW_UID: "${AIRFLOW_UID:-5001}"
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
+    AIRFLOW__API__BASE_URL: "${DOMAIN_NAME}"
+    AIRFLOW__FAB__ENABLE_PROXY_FIX: True # Needed for airflow proxy to properly redirect to https uri
     AIRFLOW__CORE__AUTH_MANAGER: airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
-    AIRFLOW__CORE__FERNET_KEY: ''
+    AIRFLOW__CORE__FERNET_KEY: "${FERNET_KEY}"
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__DEFAULT_TIMEZONE: 'America/New_York'
     AIRFLOW__WEBSERVER__DEFAULT_UI_TIMEZONE: 'America/New_York'
-    AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: '10' # set dag folder refresh in seconds
+    AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL: '60' # set dag folder refresh in seconds
     AIRFLOW__STANDARD__VENV_INSTALL_METHOD: 'uv'
     AIRFLOW__API__WORKERS: 8
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
@@ -79,7 +82,6 @@ x-airflow-common:
     AAD_TENANT_ID: ${AAD_TENANT_ID}
     AAD_CLIENT_ID: ${AAD_CLIENT_ID}
     AAD_CLIENT_SECRET: ${AAD_CLIENT_SECRET}
-    AZURE_REDIRECT_URI: ${AZURE_REDIRECT_URI}
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
@@ -292,5 +294,21 @@ services:
     depends_on:
       <<: *airflow-common-depends-on
 
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - DOMAIN_NAME=${DOMAIN_NAME}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - airflow-apiserver
 volumes:
   postgres-db-volume:
+  caddy_data:
+  caddy_config:

--- a/start_airflow.sh
+++ b/start_airflow.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+# Set Airflow UID
+export AIRFLOW_UID=5001
+
+# Create necessary folders and set permissions
+for d in logs dags plugins config; do
+  mkdir -p "$d"
+  sudo chown -R $AIRFLOW_UID:0 "$d"
+done
+
+# Log in with the VM's managed identity
+az login --identity --output none
+
+# Get Key Vault name from environment variable
+KEYVAULT_NAME="${KEYVAULT_NAME:?Environment variable KEYVAULT_NAME not set}"
+
+# Get DOMAIN_NAME from environment variable
+DOMAIN_NAME="${DOMAIN_NAME:?Environment variable DOMAIN_NAME not set}"
+export DOMAIN_NAME
+
+# Fetch secrets from Key Vault
+FERNET_KEY=$(az keyvault secret show --vault-name "$KEYVAULT_NAME" --name fernet-key --query value -o tsv)
+# SQL_CONN=$(az keyvault secret show --vault-name "$KEYVAULT_NAME" --name sql-conn --query value -o tsv)
+AAD_TENANT_ID=$(az keyvault secret show --vault-name "$KEYVAULT_NAME" --name aad-tenant-id --query value -o tsv)
+AAD_CLIENT_ID=$(az keyvault secret show --vault-name "$KEYVAULT_NAME" --name aad-client-id --query value -o tsv)
+AAD_CLIENT_SECRET=$(az keyvault secret show --vault-name "$KEYVAULT_NAME" --name aad-client-secret --query value -o tsv)
+
+
+# Write to temporary .env
+cat > .env <<EOF
+AIRFLOW_UID=$AIRFLOW_UID
+DOMAIN_NAME=$DOMAIN_NAME
+FERNET_KEY=$FERNET_KEY
+AAD_TENANT_ID=$AAD_TENANT_ID
+AAD_CLIENT_ID=$AAD_CLIENT_ID
+AAD_CLIENT_SECRET=$AAD_CLIENT_SECRET
+EOF
+
+# Start Airflow with Docker Compose
+sudo docker compose up -d
+
+# Permanently remove .env
+shred -u .env
+
+# Show running containers
+sudo docker ps


### PR DESCRIPTION
Added a start_ariflow.sh file to help make starting airflow on an Azure VM easier for initial startup.  Also added Caddy for reverse proxy and https certification.