### PR TITLE
FEAT: Flask headers and  Redis Rate Limiter

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,7 @@
 {$DOMAIN_NAME} {
-    reverse_proxy airflow-apiserver:8080
+    reverse_proxy airflow-apiserver:8080  {
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+        header_up Host {host}
+    }
 }

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,0 +1,27 @@
+# Minimal Redis config for Flask-Limiter rate limiting running in docker-compose
+# (no password, only in docker-compose network)
+# Adjust memory limits as needed based on expected load
+bind 0.0.0.0
+port 6379
+
+# Memory: 64MB is more than enough for rate limiting keys
+# Assuming a few KB per user for small DE team of 20 or so users
+maxmemory 64mb
+maxmemory-policy allkeys-lru
+
+# Persistence: disable if you only need rate limiting (keys can be lost on restart)
+save ""
+appendonly no
+
+# Networking: only allow connections from your trusted network
+protected-mode yes
+
+# Security (optional, since Redis is only in docker-compose network)
+# requirepass yourStrongPasswordHere
+
+# Performance tweaks for small instance
+databases 1        # Only one logical DB needed
+tcp-keepalive 60   # Keep connections alive
+
+# Logging
+loglevel notice

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,8 +1,6 @@
 # Minimal Redis config for Flask-Limiter rate limiting running in docker-compose
 # (no password, only in docker-compose network)
 # Adjust memory limits as needed based on expected load
-bind 0.0.0.0
-port 6379
 
 # Memory: 64MB is more than enough for rate limiting keys
 # Assuming a few KB per user for small DE team of 20 or so users

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -2,9 +2,9 @@
 # (no password, only in docker-compose network)
 # Adjust memory limits as needed based on expected load
 
-# Memory: 64MB is more than enough for rate limiting keys
+# Memory: 128MB is more than enough for rate limiting keys
 # Assuming a few KB per user for small DE team of 20 or so users
-maxmemory 64mb
+maxmemory 128mb
 maxmemory-policy allkeys-lru
 
 # Persistence: disable if you only need rate limiting (keys can be lost on restart)
@@ -13,10 +13,6 @@ appendonly no
 
 # Security (optional, since Redis is only in docker-compose network)
 # requirepass yourStrongPasswordHere
-
-# Performance tweaks for small instance
-databases 1
-tcp-keepalive 60 
 
 # Logging
 loglevel notice

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -20,8 +20,8 @@ protected-mode yes
 # requirepass yourStrongPasswordHere
 
 # Performance tweaks for small instance
-databases 1        # Only one logical DB needed
-tcp-keepalive 60   # Keep connections alive
+databases 1
+tcp-keepalive 60 
 
 # Logging
 loglevel notice

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -11,9 +11,6 @@ maxmemory-policy allkeys-lru
 save ""
 appendonly no
 
-# Networking: only allow connections from your trusted network
-protected-mode yes
-
 # Security (optional, since Redis is only in docker-compose network)
 # requirepass yourStrongPasswordHere
 

--- a/config/webserver_config.py
+++ b/config/webserver_config.py
@@ -5,7 +5,12 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 # Set up Redis for Rate Limiting
-RATELIMIT_STORAGE_URI: "redis://redis:6379"
+RATELIMIT_ENABLED = True
+RATELIMIT_STORAGE_URI: "redis://redis:6379/0"
+# using fixed window for simplicity and memory opitimization. change as needed.
+RATELIMIT_STRATEGY = "fixed-window" 
+RATELIMIT_DEFAULT = "200/hour;50/minute"
+RATELIMIT_APPLICATION = "2000/day"
 
 AUTH_TYPE = AUTH_OAUTH
 AUTH_USER_REGISTRATION = True

--- a/config/webserver_config.py
+++ b/config/webserver_config.py
@@ -6,7 +6,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 # Set up Redis for Rate Limiting
 RATELIMIT_ENABLED = True
-RATELIMIT_STORAGE_URI: "redis://redis:6379/0"
+RATELIMIT_STORAGE_URI = "redis://redis:6379"
 # using fixed window for simplicity and memory opitimization. change as needed.
 RATELIMIT_STRATEGY = "fixed-window" 
 RATELIMIT_DEFAULT = "200/hour;50/minute"

--- a/config/webserver_config.py
+++ b/config/webserver_config.py
@@ -4,10 +4,12 @@ from airflow.providers.fab.auth_manager.security_manager.override import FabAirf
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-# RATELIMIT_STORAGE_URI: "redis://redis:6379"
+# Set up Redis for Rate Limiting
+RATELIMIT_STORAGE_URI: "redis://redis:6379"
+
 AUTH_TYPE = AUTH_OAUTH
 AUTH_USER_REGISTRATION = True
-AUTH_USER_REGISTRATION_ROLE = "Admin"  # For testing, gives all new users admin rights, CHANGE TO Public FOR PRODUCTION
+AUTH_USER_REGISTRATION_ROLE = "Public"  # For testing, gives all new users admin rights, CHANGE TO Public FOR PRODUCTION
 AUTH_ROLES_SYNC_AT_LOGIN = True
 AUTH_ROLES_MAPPING = {
     "airflow_prod_admin": ["Admin"],

--- a/dags/hello_world.py
+++ b/dags/hello_world.py
@@ -3,7 +3,7 @@ from airflow.operators.python import PythonOperator
 from datetime import datetime
 
 def hello_world():
-    print("Hello, Raffi!")
+    print("Hello, World!")
 
 with DAG(
     dag_id='hello_world_dag',

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,6 +119,9 @@ services:
     image: redis:7.2-bookworm
     expose:
       - 6379
+    volumes:
+      - ./config/redis.conf:/usr/local/etc/redis/redis.conf
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
Pass headers from CAddy to flask to prevent 401 unauthorized error on startup.


Added Redis as the production rate limiter for FAB and also added a redis conf.